### PR TITLE
Check points passed to `equation_of_line` differ

### DIFF
--- a/maths.py
+++ b/maths.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def equation_of_line(a, b):
     """
     Determine the equation of the line passing through two points.
@@ -6,6 +9,8 @@ def equation_of_line(a, b):
     :arg b: the second point the line passes through
     :return: function of two variables defining the line
     """
+    if np.allclose(a, b):
+        raise ValueError("Cannot determine a unique line through {a} and {b}.")
     x0, y0 = a
     x1, y1 = b
 

--- a/test_maths.py
+++ b/test_maths.py
@@ -17,3 +17,8 @@ def test_equation(a, b, condition):
         iszero = np.isclose(f(x, y), 0)
         if (not iszero if condition(x, y) else iszero):
             raise AssertionError(f"f({x},{y}) {'!=' if condition(x, y) else '=='} 0")
+
+
+def test_single_point():
+    with pytest.raises(ValueError):
+        equation_of_line((0, 0), (0, 0))


### PR DESCRIPTION
Closes #8.

This PR adds a check that the two points passed to `equation_of_line` are not identical. If they are, there are infinitely many lines passing through the points so we raise an error.

The PR also adds a test to check that this error gets raised as expected.